### PR TITLE
Make dependency analysing configurable (false by default)

### DIFF
--- a/lib/inversion_of_control/configuration.rb
+++ b/lib/inversion_of_control/configuration.rb
@@ -4,12 +4,14 @@ module InversionOfControl
     attr_accessor :auto_resolve_unregistered_dependency
     attr_accessor :instantiate_dependencies
     attr_accessor :inject_on_initialize
+    attr_accessor :analyze_dependencies
 
     def initialize
       @dependencies = {}
       @auto_resolve_unregistered_dependency = false
       @instantiate_dependencies = false
       @inject_on_initialize = false
+      @analyze_dependencies = false
     end
   end
 end

--- a/lib/inversion_of_control/dsl.rb
+++ b/lib/inversion_of_control/dsl.rb
@@ -8,7 +8,9 @@ module InversionOfControl
     end
 
     def inject_dependencies(*dependencies)
-      InversionOfControl.dependency_analyzer.track_class(self)
+      if InversionOfControl.configuration.analyze_dependencies
+        InversionOfControl.dependency_analyzer.track_class(self)
+      end
 
       if dependencies.nil?
         self.ancestors.each_with_index do |ancestor, index|

--- a/spec/inversion_of_control/dsl_spec.rb
+++ b/spec/inversion_of_control/dsl_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe InversionOfControl::DSL do
-  describe ".inject" do
+  describe ".inject_dependencies" do
 
     context "with no dependencies implicitly" do
       let(:dummy_class) do
@@ -51,6 +51,37 @@ describe InversionOfControl::DSL do
 
       it "registers the dependencies on the class" do
         expect(dummy_class.dependencies).to match_array([:example_dependency_1, :example_dependency_2])
+      end
+    end
+
+    context "tracking dependencies" do
+      before(:each) do
+        if defined?(analyze_dependencies)
+          InversionOfControl.configuration.analyze_dependencies = analyze_dependencies
+        end
+      end
+
+      let!(:dummy_class) do
+        Class.new do
+          include InversionOfControl
+          inject_dependencies()
+        end
+      end
+
+      let(:dependency_analyzer) { InversionOfControl.dependency_analyzer }
+
+      context "by default" do
+        it "does not track the class in the dependency analyzer" do
+          expect(dependency_analyzer.tracked_classes).to be_empty
+        end
+      end
+
+      context "with dependency tracking turned on" do
+        let(:analyze_dependencies) { true }
+        it "tracks the class in the dependency analyzer" do
+          InversionOfControl.configuration.analyze_dependencies = true
+          expect(dependency_analyzer.tracked_classes).to match_array(dummy_class)
+        end
       end
     end
   end

--- a/spec/inversion_of_control_spec.rb
+++ b/spec/inversion_of_control_spec.rb
@@ -69,11 +69,6 @@ describe InversionOfControl do
       it "adds the assemble method for instantiation" do
         expect(dummy_class).to respond_to(:assemble)
       end
-
-      it "tracks the class in the dependency analyzer" do
-        da = InversionOfControl.dependency_analyzer
-        expect(da.tracked_classes).to match_array(dummy_class)
-      end
     end
   end
 


### PR DESCRIPTION
The reason for this is that the generation of dependency graphs ought to
happen when the code is not running in production, and so dependencies
should only be tracked then.
